### PR TITLE
Fix read-sequence semantics in read-internal

### DIFF
--- a/src/store/fs-store.lisp
+++ b/src/store/fs-store.lisp
@@ -159,8 +159,8 @@
     (let ((position (pos self)))
       (when (not (= position (file-position file)))
 	(file-position file position)))
-    (let ((num-bytes-read (read-sequence b file :start offset :end (+ offset length))))
-      (unless (= num-bytes-read length)
+    (let ((after-index (read-sequence b file :start offset :end (+ offset length))))
+      (unless (= after-index (+ offset length))
 	(error "End of file error while reading ~S" file))))
   (values))
 


### PR DESCRIPTION
READ-SEQUENCE returns the first index in the sequence that is not updated, /not/ a count of the number of elements read. Adjust EOF-checking logic accordingly.